### PR TITLE
Support defining security mechanisms for Swagger

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1659,6 +1659,18 @@ There are several configuration parameters that determine the structure of the g
     By default to encourage good security practices, ``['https']`` is specified.
 
 
+``config:swagger_security_definitions``
+    If the API requires authentication, you can specify details of the authentication mechanisms supported as a (Hash) value here.
+    See [https://swagger.io/docs/specification/2-0/authentication/] for details of what values can be specified
+    By default, no security is defined.
+
+``config.swagger_global_security``
+    If the API requires authentication, you can specify which of the authentication mechanisms are supported by all API operations as an Array of hashes here.
+    This should be used in conjunction with the mechanisms defined by ``swagger_security_definitions``.
+    See [https://swagger.io/docs/specification/2-0/authentication/] for details of what values can be specified
+    By default, no security is defined.
+
+
 Known limitations of the current implementation
 -------------------------------------------------
 * There is currently no way to document the structure and content-type of the data returned from a method
@@ -1668,6 +1680,7 @@ Known limitations of the current implementation
 * It is not possible to leverage all of the parameter type/format capabilities of swagger
 * Only OpenAPI 2.0 is supported
 * Responses are defined inline and not as a $ref
+* It is not possible to specify per-operation security requirements (only global)
 
 ====================================
  Dynamic Swagger generation

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -12,7 +12,7 @@ module Apipie
       :swagger_include_warning_tags, :swagger_content_type_input, :swagger_json_input_uses_refs,
       :swagger_suppress_warnings, :swagger_api_host, :swagger_generate_x_computed_id_field,
       :swagger_allow_additional_properties_in_response, :swagger_responses_use_refs,
-      :swagger_schemes
+      :swagger_schemes, :swagger_security_definitions, :swagger_global_security
 
     alias_method :validate?, :validate
     alias_method :required_by_default?, :required_by_default
@@ -183,6 +183,8 @@ module Apipie
       @swagger_allow_additional_properties_in_response = false
       @swagger_responses_use_refs = true
       @swagger_schemes = [:https]
+      @swagger_security_definitions = {}
+      @swagger_global_security = []
     end
   end
 end

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -74,7 +74,9 @@ module Apipie
           paths: {},
           definitions: {},
           schemes: Apipie.configuration.swagger_schemes,
-          tags: []
+          tags: [],
+          securityDefinitions: Apipie.configuration.swagger_security_definitions,
+          security: Apipie.configuration.swagger_global_security
       }
 
       if Apipie.configuration.swagger_api_host


### PR DESCRIPTION
Generated Swagger documentation allows the API to specify what
authentication mechanisms are available and which are required.

This adds support (through configuration) for the API to include that
information in the generated swagger docs
https://swagger.io/docs/specification/2-0/authentication/